### PR TITLE
Add the first test input, a single new compute engine instance.

### DIFF
--- a/testdata/new-compute-instance/config/main.tf
+++ b/testdata/new-compute-instance/config/main.tf
@@ -1,0 +1,38 @@
+# See https://www.terraform.io/docs/providers/google/r/compute_instance.html.
+
+resource "google_compute_instance" "default" {
+  name         = "test"
+  machine_type = "n1-standard-1"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  // Local SSD disk
+  scratch_disk {
+    interface = "SCSI"
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  metadata_startup_script = "echo hi > /test.txt"
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}

--- a/testdata/new-compute-instance/tfplan.json
+++ b/testdata/new-compute-instance/tfplan.json
@@ -1,0 +1,300 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.12.25",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_instance.default",
+          "mode": "managed",
+          "type": "google_compute_instance",
+          "name": "default",
+          "provider_name": "google",
+          "schema_version": 6,
+          "values": {
+            "allow_stopping_for_update": null,
+            "attached_disk": [],
+            "boot_disk": [
+              {
+                "auto_delete": true,
+                "disk_encryption_key_raw": null,
+                "initialize_params": [
+                  {
+                    "image": "debian-cloud/debian-9"
+                  }
+                ],
+                "mode": "READ_WRITE"
+              }
+            ],
+            "can_ip_forward": false,
+            "deletion_protection": false,
+            "description": null,
+            "disk": [],
+            "enable_display": null,
+            "hostname": null,
+            "labels": null,
+            "machine_type": "n1-standard-1",
+            "metadata": {
+              "foo": "bar"
+            },
+            "metadata_startup_script": "echo hi > /test.txt",
+            "min_cpu_platform": null,
+            "name": "test",
+            "network_interface": [
+              {
+                "access_config": [
+                  {
+                    "public_ptr_domain_name": null
+                  }
+                ],
+                "alias_ip_range": [],
+                "network": "default"
+              }
+            ],
+            "scratch_disk": [
+              {
+                "interface": "SCSI"
+              }
+            ],
+            "service_account": [
+              {
+                "scopes": [
+                  "https://www.googleapis.com/auth/compute.readonly",
+                  "https://www.googleapis.com/auth/devstorage.read_only",
+                  "https://www.googleapis.com/auth/userinfo.email"
+                ]
+              }
+            ],
+            "shielded_instance_config": [],
+            "tags": [
+              "bar",
+              "foo"
+            ],
+            "timeouts": null,
+            "zone": "us-central1-a"
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_compute_instance.default",
+      "mode": "managed",
+      "type": "google_compute_instance",
+      "name": "default",
+      "provider_name": "google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "allow_stopping_for_update": null,
+          "attached_disk": [],
+          "boot_disk": [
+            {
+              "auto_delete": true,
+              "disk_encryption_key_raw": null,
+              "initialize_params": [
+                {
+                  "image": "debian-cloud/debian-9"
+                }
+              ],
+              "mode": "READ_WRITE"
+            }
+          ],
+          "can_ip_forward": false,
+          "deletion_protection": false,
+          "description": null,
+          "disk": [],
+          "enable_display": null,
+          "hostname": null,
+          "labels": null,
+          "machine_type": "n1-standard-1",
+          "metadata": {
+            "foo": "bar"
+          },
+          "metadata_startup_script": "echo hi > /test.txt",
+          "min_cpu_platform": null,
+          "name": "test",
+          "network_interface": [
+            {
+              "access_config": [
+                {
+                  "public_ptr_domain_name": null
+                }
+              ],
+              "alias_ip_range": [],
+              "network": "default"
+            }
+          ],
+          "scratch_disk": [
+            {
+              "interface": "SCSI"
+            }
+          ],
+          "service_account": [
+            {
+              "scopes": [
+                "https://www.googleapis.com/auth/compute.readonly",
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ]
+            }
+          ],
+          "shielded_instance_config": [],
+          "tags": [
+            "bar",
+            "foo"
+          ],
+          "timeouts": null,
+          "zone": "us-central1-a"
+        },
+        "after_unknown": {
+          "attached_disk": [],
+          "boot_disk": [
+            {
+              "device_name": true,
+              "disk_encryption_key_sha256": true,
+              "initialize_params": [
+                {
+                  "labels": true,
+                  "size": true,
+                  "type": true
+                }
+              ],
+              "kms_key_self_link": true,
+              "source": true
+            }
+          ],
+          "cpu_platform": true,
+          "disk": [],
+          "guest_accelerator": true,
+          "id": true,
+          "instance_id": true,
+          "label_fingerprint": true,
+          "metadata": {},
+          "metadata_fingerprint": true,
+          "network_interface": [
+            {
+              "access_config": [
+                {
+                  "assigned_nat_ip": true,
+                  "nat_ip": true,
+                  "network_tier": true
+                }
+              ],
+              "address": true,
+              "alias_ip_range": [],
+              "name": true,
+              "network_ip": true,
+              "subnetwork": true,
+              "subnetwork_project": true
+            }
+          ],
+          "project": true,
+          "scheduling": true,
+          "scratch_disk": [
+            {}
+          ],
+          "self_link": true,
+          "service_account": [
+            {
+              "email": true,
+              "scopes": [
+                false,
+                false,
+                false
+              ]
+            }
+          ],
+          "shielded_instance_config": [],
+          "tags": [
+            false,
+            false
+          ],
+          "tags_fingerprint": true
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_instance.default",
+          "mode": "managed",
+          "type": "google_compute_instance",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "boot_disk": [
+              {
+                "initialize_params": [
+                  {
+                    "image": {
+                      "constant_value": "debian-cloud/debian-9"
+                    }
+                  }
+                ]
+              }
+            ],
+            "machine_type": {
+              "constant_value": "n1-standard-1"
+            },
+            "metadata": {
+              "constant_value": {
+                "foo": "bar"
+              }
+            },
+            "metadata_startup_script": {
+              "constant_value": "echo hi > /test.txt"
+            },
+            "name": {
+              "constant_value": "test"
+            },
+            "network_interface": [
+              {
+                "access_config": [
+                  {}
+                ],
+                "network": {
+                  "constant_value": "default"
+                }
+              }
+            ],
+            "scratch_disk": [
+              {
+                "interface": {
+                  "constant_value": "SCSI"
+                }
+              }
+            ],
+            "service_account": [
+              {
+                "scopes": {
+                  "constant_value": [
+                    "userinfo-email",
+                    "compute-ro",
+                    "storage-ro"
+                  ]
+                }
+              }
+            ],
+            "tags": {
+              "constant_value": [
+                "foo",
+                "bar"
+              ]
+            },
+            "zone": {
+              "constant_value": "us-central1-a"
+            }
+          },
+          "schema_version": 6
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I'm also including the Terraform configuration from which tfplan.json was
generated. This is useful in case tfplan.json needs to be recreated. For now,
this is just an ad-hoc, manual process.