### PR TITLE
Made PricingInfo hold unit pricing in nanos.

### DIFF
--- a/billing/info.go
+++ b/billing/info.go
@@ -10,6 +10,8 @@ import (
 	billingpb "google.golang.org/genproto/googleapis/cloud/billing/v1"
 )
 
+const nano = float64(1000 * 1000 * 1000)
+
 func fitsDescription(sku *billingpb.Sku, contains, omits []string) bool {
 	if contains != nil {
 		for _, d := range contains {
@@ -47,18 +49,17 @@ func fitsRegion(sku *billingpb.Sku, region string) bool {
 	return false
 }
 
-// GetPricingInfo returns the pricing information of an SKU.
-func GetPricingInfo(sku *billingpb.Sku) (usageUnit string, hourlyUnitPrice int64, currencyType, currencyUnit string) {
-	currencyUnit = "nano"
+// PricingInfo returns the pricing information of an SKU.
+func PricingInfo(sku *billingpb.Sku) (usageUnit string, pricePerUnit float64, currencyType string) {
 	pExpr := sku.PricingInfo[0].PricingExpression
-	usageUnit = pExpr.UsageUnitDescription
+	usageUnit = strings.Split(pExpr.UsageUnitDescription, " ")[0]
 
 	if pExpr.TieredRates == nil || len(pExpr.TieredRates) == 0 {
 		return
 	}
 
 	unitPrice := pExpr.TieredRates[0].UnitPrice
-	hourlyUnitPrice = int64(unitPrice.Nanos)
+	pricePerUnit = float64(unitPrice.Nanos) / nano
 	currencyType = unitPrice.CurrencyCode
 	return
 }

--- a/io/web/web_template.gohtml
+++ b/io/web/web_template.gohtml
@@ -24,12 +24,12 @@
             </tr>
             <tr>
                 <td colspan="1"></td>
-                <td colspan="1">Cost per Unit</td>
+                <td colspan="1">Cost per unit</td>
                 <td colspan="1">Number of units</td>
                 <td colspan="1">Cost of units</td>
-                <td colspan="1">Cost per Unit</td>
+                <td colspan="1">Cost per unit</td>
                 <td colspan="1">Number of units</td>
-                <td colspan="1">Cost per Unit</td>
+                <td colspan="1">Cost of units</td>
                 <td colspan="1">Cost of units</td>
             </tr>
             {{range $i, $row := .PricingInfo}}

--- a/resources/compute_instance_test.go
+++ b/resources/compute_instance_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"math"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 
@@ -51,7 +52,7 @@ func mapToDescription(skus []*billingpb.Sku) (mapped []string) {
 func mapToPricingInfo(skus []*billingpb.Sku) (mapped []PricingInfo) {
 	for _, sku := range skus {
 		p := PricingInfo{}
-		p.fillInfo(sku)
+		p.fillHourlyBase(sku)
 		mapped = append(mapped, p)
 	}
 	return
@@ -91,10 +92,7 @@ func TestCompletePricingInfo(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.skuObj.completePricingInfo(test.skus)
 			// Test fails if the error value is different or with different messages or if the pricing information differs from the expected one.
-			f1 := (err == nil && test.err != nil) || (err != nil && test.err == nil)
-			f2 := err != nil && test.err != nil && err.Error() != test.err.Error()
-			f3 := test.pricing != test.skuObj.getPricingInfo()
-			if f1 || f2 || f3 {
+			if !reflect.DeepEqual(err, test.err) || test.pricing != test.skuObj.getPricingInfo() {
 				t.Errorf("{%+v}.completePricingInfo(%+v) -> %+v, %+v; want %+v, %+v",
 					test.skuObj, mapToDescription(test.skus), test.skuObj.getPricingInfo(), err, test.pricing, test.err)
 			}
@@ -103,20 +101,20 @@ func TestCompletePricingInfo(t *testing.T) {
 }
 
 func TestCoreGetTotalPrice(t *testing.T) {
-	c1 := CoreInfo{Number: 2, Fractional: 1, UnitPricing: PricingInfo{HourlyUnitPrice: 6980000}}
-	c2 := CoreInfo{Number: 4, Fractional: 0.125, UnitPricing: PricingInfo{HourlyUnitPrice: 44856000}}
-	c3 := CoreInfo{Number: 32, Fractional: 0.5, UnitPricing: PricingInfo{HourlyUnitPrice: 1121733}}
-	c4 := CoreInfo{Number: 16, Fractional: 1, UnitPricing: PricingInfo{HourlyUnitPrice: 2701000}}
+	c1 := CoreInfo{Number: 2, Fractional: 1, UnitPricing: PricingInfo{HourlyUnitPrice: 0.06}}
+	c2 := CoreInfo{Number: 4, Fractional: 0.125, UnitPricing: PricingInfo{HourlyUnitPrice: 0.44}}
+	c3 := CoreInfo{Number: 32, Fractional: 0.5, UnitPricing: PricingInfo{HourlyUnitPrice: 0.101}}
+	c4 := CoreInfo{Number: 16, Fractional: 1, UnitPricing: PricingInfo{HourlyUnitPrice: 2.7}}
 
 	tests := []struct {
 		name  string
 		core  CoreInfo
 		price float64
 	}{
-		{"no_fractional_0", c1, float64(6980000) * 2 / nano},
-		{"no_fractiona_1", c4, float64(2701000) * 16 / nano},
-		{"fractional_0", c2, float64(44856000) * 4 / nano * 0.125},
-		{"fractional_1", c3, float64(1121733) * 32 / nano * 0.5},
+		{"no_fractional_0", c1, 0.06 * 2},
+		{"no_fractiona_1", c4, 2.7 * 16},
+		{"fractional_0", c2, 0.44 * 4 * 0.125},
+		{"fractional_1", c3, 0.101 * 32 * 0.5},
 	}
 
 	for _, test := range tests {
@@ -129,12 +127,12 @@ func TestCoreGetTotalPrice(t *testing.T) {
 }
 
 func TestMemGetTotalPrice(t *testing.T) {
-	m1 := MemoryInfo{AmountGiB: 100, UnitPricing: PricingInfo{HourlyUnitPrice: 6980000, UsageUnit: "gigabyte hour"}}
-	m2 := MemoryInfo{AmountGiB: 50, UnitPricing: PricingInfo{HourlyUnitPrice: 44856000, UsageUnit: "pebibyte hour"}}
-	m3 := MemoryInfo{AmountGiB: 320, UnitPricing: PricingInfo{HourlyUnitPrice: 1121733, UsageUnit: "tebibyte hour"}}
-	m4 := MemoryInfo{AmountGiB: 16, UnitPricing: PricingInfo{HourlyUnitPrice: 2701000, UsageUnit: "gibibyte hour"}}
-	m5 := MemoryInfo{AmountGiB: 160, UnitPricing: PricingInfo{HourlyUnitPrice: 2701000, UsageUnit: "giBibyte hour"}}
-	m6 := MemoryInfo{AmountGiB: 160, UnitPricing: PricingInfo{HourlyUnitPrice: 2701000, UsageUnit: "mebibite hour"}}
+	m1 := MemoryInfo{AmountGiB: 100, UnitPricing: PricingInfo{HourlyUnitPrice: 0.06, UsageUnit: "gigabyte"}}
+	m2 := MemoryInfo{AmountGiB: 50, UnitPricing: PricingInfo{HourlyUnitPrice: 0.44, UsageUnit: "pebibyte"}}
+	m3 := MemoryInfo{AmountGiB: 320, UnitPricing: PricingInfo{HourlyUnitPrice: 0.101, UsageUnit: "tebibyte"}}
+	m4 := MemoryInfo{AmountGiB: 16, UnitPricing: PricingInfo{HourlyUnitPrice: 2.7, UsageUnit: "gibibyte"}}
+	m5 := MemoryInfo{AmountGiB: 160, UnitPricing: PricingInfo{HourlyUnitPrice: 2.7, UsageUnit: "giBibyte"}}
+	m6 := MemoryInfo{AmountGiB: 160, UnitPricing: PricingInfo{HourlyUnitPrice: 2.7, UsageUnit: "mebibite"}}
 
 	gb := float64(1000 * 1000 * 1000)
 	gib := float64(1024 * 1024 * 1024)
@@ -145,10 +143,10 @@ func TestMemGetTotalPrice(t *testing.T) {
 		price float64
 		err   error
 	}{
-		{"gigabyte_unit", m1, float64(6980000) / nano * 100 * gib / gb, nil},
-		{"pebibyte_unit", m2, float64(44856000) / nano * 50 / (1024 * 1024), nil},
-		{"tebibyte_unit", m3, float64(1121733) / nano * 320 / 1024, nil},
-		{"gibibyte_unit", m4, float64(2701000) / nano * 16, nil},
+		{"gigabyte_unit", m1, 0.06 * 100 * gib / gb, nil},
+		{"pebibyte_unit", m2, 0.44 * 50 / (1024 * 1024), nil},
+		{"tebibyte_unit", m3, 0.101 * 320 / 1024, nil},
+		{"gibibyte_unit", m4, 2.7 * 16, nil},
 		{"wrong_unit_0", m5, 0, fmt.Errorf("unknown final unit giBibyte")},
 		{"wrong_unit_1", m6, 0, fmt.Errorf("unknown final unit mebibite")},
 	}
@@ -167,16 +165,16 @@ func TestMemGetTotalPrice(t *testing.T) {
 }
 
 func TestGetDelta(t *testing.T) {
-	c1 := CoreInfo{Number: 4, Fractional: 1, UnitPricing: PricingInfo{HourlyUnitPrice: 12345}}
-	m1 := MemoryInfo{AmountGiB: 1000, UnitPricing: PricingInfo{HourlyUnitPrice: 23455, UsageUnit: "gibibyte hour"}}
+	c1 := CoreInfo{Number: 4, Fractional: 1, UnitPricing: PricingInfo{HourlyUnitPrice: 0.12345}}
+	m1 := MemoryInfo{AmountGiB: 1000, UnitPricing: PricingInfo{HourlyUnitPrice: 0.23455, UsageUnit: "gibibyte"}}
 	i1 := ComputeInstance{Cores: c1, Memory: m1}
 
-	c2 := CoreInfo{Number: 16, Fractional: 1, UnitPricing: PricingInfo{HourlyUnitPrice: 12345}}
-	m2 := MemoryInfo{AmountGiB: 500, UnitPricing: PricingInfo{HourlyUnitPrice: 23455, UsageUnit: "gibibyte hour"}}
+	c2 := CoreInfo{Number: 16, Fractional: 1, UnitPricing: PricingInfo{HourlyUnitPrice: 0.12345}}
+	m2 := MemoryInfo{AmountGiB: 500, UnitPricing: PricingInfo{HourlyUnitPrice: 0.23455, UsageUnit: "gibibyte"}}
 	i2 := ComputeInstance{Cores: c2, Memory: m2}
 
-	c3 := CoreInfo{Number: 32, Fractional: 1, UnitPricing: PricingInfo{HourlyUnitPrice: 785678}}
-	m3 := MemoryInfo{AmountGiB: 2000, UnitPricing: PricingInfo{HourlyUnitPrice: 235977, UsageUnit: "gigbyte hour"}}
+	c3 := CoreInfo{Number: 32, Fractional: 1, UnitPricing: PricingInfo{HourlyUnitPrice: 0.785678}}
+	m3 := MemoryInfo{AmountGiB: 2000, UnitPricing: PricingInfo{HourlyUnitPrice: 0.235977, UsageUnit: "gigbyte"}}
 	i3 := ComputeInstance{Name: "test", MachineType: "n1-standard-1", Cores: c3, Memory: m3}
 
 	tests := []struct {
@@ -186,12 +184,12 @@ func TestGetDelta(t *testing.T) {
 		dmem  float64
 		err   error
 	}{
-		{"create", ComputeInstanceState{Before: nil, After: &i1}, 4 * 12345, 1000 * 23455, nil},
-		{"destroy", ComputeInstanceState{Before: &i1, After: nil}, -4 * 12345, -1000 * 23455, nil},
+		{"create", ComputeInstanceState{Before: nil, After: &i1}, 4 * 0.12345, 1000 * 0.23455, nil},
+		{"destroy", ComputeInstanceState{Before: &i1, After: nil}, -4 * 0.12345, -1000 * 0.23455, nil},
 		{"wrong_before", ComputeInstanceState{Before: &i3, After: &i2}, 0, 0, fmt.Errorf("test(n1-standard-1): unknown final unit gigbyte")},
 		{"wrong_after", ComputeInstanceState{Before: &i1, After: &i3}, 0, 0, fmt.Errorf("test(n1-standard-1): unknown final unit gigbyte")},
-		{"update_0", ComputeInstanceState{Before: &i1, After: &i2}, (16 - 4) * 12345, (500 - 1000) * 23455, nil},
-		{"update_1", ComputeInstanceState{Before: &i2, After: &i1}, -(16 - 4) * 12345, -(500 - 1000) * 23455, nil},
+		{"update_0", ComputeInstanceState{Before: &i1, After: &i2}, (16 - 4) * 0.12345, (500 - 1000) * 0.23455, nil},
+		{"update_1", ComputeInstanceState{Before: &i2, After: &i1}, -(16 - 4) * 0.12345, -(500 - 1000) * 0.23455, nil},
 	}
 
 	for _, test := range tests {
@@ -200,7 +198,7 @@ func TestGetDelta(t *testing.T) {
 			f1 := (err == nil && test.err != nil) || (err != nil && test.err == nil)
 			f2 := err != nil && test.err != nil && err.Error() != test.err.Error()
 			// Test fails if the error value is different or with different messages or if the return values differs from the expected ones.
-			if f1 || f2 || math.Abs(dcore-test.dcore/nano) > epsilon || math.Abs(dmem-test.dmem/nano) > epsilon {
+			if f1 || f2 || math.Abs(dcore-test.dcore) > epsilon || math.Abs(dmem-test.dmem) > epsilon {
 				t.Errorf("%+v.getDelta() = %f, %f, %s ; want %f, %f, %s",
 					test.state, dcore, dmem, err, test.dcore, test.dmem, test.err)
 			}

--- a/resources/general.go
+++ b/resources/general.go
@@ -9,24 +9,28 @@ import (
 )
 
 const (
-	nano    = float64(1000 * 1000 * 1000)
-	epsilon = 1e-10
+	nano            = float64(1000 * 1000 * 1000)
+	epsilon         = 1e-10
+	hourlyToMonthly = float64(24 * 30)
+	hourlyToYearly  = float64(24 * 365)
 )
 
 // PricingInfo stores the information from the billing API.
 type PricingInfo struct {
 	UsageUnit       string
-	HourlyUnitPrice int64
+	HourlyUnitPrice float64
 	CurrencyType    string
-	CurrencyUnit    string
 }
 
-func (p *PricingInfo) fillInfo(sku *billingpb.Sku) {
-	usageUnit, hourlyUnitPrice, currencyType, currencyUnit := billing.GetPricingInfo(sku)
+func (p *PricingInfo) fillHourlyBase(sku *billingpb.Sku) {
+	p.UsageUnit, p.HourlyUnitPrice, p.CurrencyType = billing.PricingInfo(sku)
+}
+
+func (p *PricingInfo) fillMonthlyBase(sku *billingpb.Sku) {
+	usageUnit, monthly, currencyType := billing.PricingInfo(sku)
 	p.UsageUnit = usageUnit
-	p.HourlyUnitPrice = hourlyUnitPrice
+	p.HourlyUnitPrice = monthly / hourlyToMonthly
 	p.CurrencyType = currencyType
-	p.CurrencyUnit = currencyUnit
 }
 
 //ResourceState is the interface of a general before/after resource state(ComputeInstance,...).


### PR DESCRIPTION
Not all resources are charged per hour, so convertion with precision is needed. Made hourly price float64 and removed redundant currency unit always equal to "nano".
Hourly Price is now already expressed in nanos. Changed pricing usage unit to the first word from the description ("gibibyte hour" -> "gibibyte").
Fixed web template typos.