### PR TITLE
Added correct tier rate determination.

### DIFF
--- a/billing/info_test.go
+++ b/billing/info_test.go
@@ -81,18 +81,19 @@ func TestGetPricingInfo(t *testing.T) {
 	tests := []struct {
 		name         string
 		sku          *billingpb.Sku
+		f            func(*billingpb.PricingExpression_TierRate) bool
 		usageUnit    string
 		pricePerUnit float64
 		currencyType string
 	}{
-		{"no_pricing", skus[6], "hour", 0, ""},
-		{"one_pricing", skus[0], "gibibyte", 5928000 / nano, "USD"},
-		{"more_pricing", skus[5], "gibibyte", 5696340 / nano, "USD"},
+		{"no_pricing", skus[6], func(*billingpb.PricingExpression_TierRate) bool { return true }, "hour", 0, ""},
+		{"one_pricing", skus[0], func(*billingpb.PricingExpression_TierRate) bool { return true }, "gibibyte", 5928000 / nano, "USD"},
+		{"more_pricing", skus[5], func(*billingpb.PricingExpression_TierRate) bool { return true }, "gibibyte", 5226000 / nano, "USD"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			usageUnit, pricePerUnit, currencyType := PricingInfo(test.sku)
+			usageUnit, pricePerUnit, currencyType := PricingInfo(test.sku, test.f)
 			// Test fails if any return value is different than the expected one.
 			if usageUnit != test.usageUnit || math.Abs(pricePerUnit-test.pricePerUnit) > epsilon || currencyType != test.currencyType {
 				t.Errorf("GetPricingInfo(sku) = %+v, %+v, %+v; want %+v, %+v, %+v",

--- a/resources/compute_disk_test.go
+++ b/resources/compute_disk_test.go
@@ -142,9 +142,8 @@ func TestDiskStateGeneralChanges(t *testing.T) {
 }
 
 func TestDiskStateCostChanges(t *testing.T) {
-	d1 := &ComputeDisk{UnitPricing: PricingInfo{HourlyUnitPrice: 0.1, UsageUnit: "gibibite month"}}
-	d2 := &ComputeDisk{SizeGiB: 150, UnitPricing: PricingInfo{HourlyUnitPrice: 0.1, UsageUnit: "gibibyte"}}
-	d3 := &ComputeDisk{SizeGiB: 500, UnitPricing: PricingInfo{HourlyUnitPrice: 0.3, UsageUnit: "gibibyte"}}
+	d1 := &ComputeDisk{SizeGiB: 150, UnitPricing: PricingInfo{HourlyUnitPrice: 0.1, UsageUnit: "gibibyte"}}
+	d2 := &ComputeDisk{SizeGiB: 500, UnitPricing: PricingInfo{HourlyUnitPrice: 0.3, UsageUnit: "gibibyte"}}
 
 	tests := []struct {
 		name         string
@@ -154,24 +153,22 @@ func TestDiskStateCostChanges(t *testing.T) {
 		units1       int64
 		units2       int64
 		delta        float64
-		err          error
 	}{
-		{"invalid_memory_unit", &ComputeDiskState{Before: d1, After: d1}, 0, 0, 0, 0, 0, fmt.Errorf("invalid final unit gibibite")},
-		{"create", &ComputeDiskState{Before: nil, After: d2}, 0, 0.1, 0, 150, 0.1 * 150, nil},
-		{"destroy", &ComputeDiskState{Before: d2, After: nil}, 0.1, 0, 150, 0, -0.1 * 150, nil},
-		{"update", &ComputeDiskState{Before: d2, After: d3}, 0.1, 0.3, 150, 500, 0.3*500 - 0.1*150, nil},
+		{"create", &ComputeDiskState{Before: nil, After: d1}, 0, 0.1, 0, 150, 0.1 * 150},
+		{"destroy", &ComputeDiskState{Before: d1, After: nil}, 0.1, 0, 150, 0, -0.1 * 150},
+		{"update", &ComputeDiskState{Before: d1, After: d2}, 0.1, 0.3, 150, 500, 0.3*500 - 0.1*150},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			costPerUnit1, costPerUnit2, units1, units2, delta, err := test.state.costChanges()
+			costPerUnit1, costPerUnit2, units1, units2, delta := test.state.costChanges()
 			// Test fails if error or return values are different.
 			f1 := costPerUnit1 != test.costPerUnit1 || costPerUnit2 != test.costPerUnit2
 			f2 := units1 != test.units1 || units2 != test.units2 || delta != test.delta
 			if f1 || f2 {
-				t.Errorf("state.costChanges() = %f, %f, %d, %d, %f, %+v ; want %f, %f, %d, %d, %f, %+v",
-					costPerUnit1, costPerUnit2, units1, units2, delta, err,
-					test.costPerUnit1, test.costPerUnit2, test.units1, test.units2, test.delta, test.err)
+				t.Errorf("state.costChanges() = %f, %f, %d, %d, %f ; want %f, %f, %d, %d, %f",
+					costPerUnit1, costPerUnit2, units1, units2, delta,
+					test.costPerUnit1, test.costPerUnit2, test.units1, test.units2, test.delta)
 			}
 		})
 	}

--- a/resources/compute_instance_test.go
+++ b/resources/compute_instance_test.go
@@ -49,10 +49,10 @@ func mapToDescription(skus []*billingpb.Sku) (mapped []string) {
 	return
 }
 
-func mapToPricingInfo(skus []*billingpb.Sku) (mapped []PricingInfo) {
+func mapToPricingInfo(skus []*billingpb.Sku, correctTierRate func(*billingpb.PricingExpression_TierRate) bool) (mapped []PricingInfo) {
 	for _, sku := range skus {
 		p := PricingInfo{}
-		p.fillHourlyBase(sku)
+		p.fillHourlyBase(sku, correctTierRate)
 		mapped = append(mapped, p)
 	}
 	return
@@ -71,7 +71,7 @@ func TestCompletePricingInfo(t *testing.T) {
 	m2 := MemoryInfo{ResourceGroup: "N1Standard"}
 	m3 := m1
 
-	p := mapToPricingInfo(skus)
+	p := mapToPricingInfo(skus, func(*billingpb.PricingExpression_TierRate) bool { return true })
 
 	tests := []struct {
 		name    string

--- a/resources/general.go
+++ b/resources/general.go
@@ -13,12 +13,12 @@ type PricingInfo struct {
 	CurrencyType    string
 }
 
-func (p *PricingInfo) fillHourlyBase(sku *billingpb.Sku) {
-	p.UsageUnit, p.HourlyUnitPrice, p.CurrencyType = billing.PricingInfo(sku)
+func (p *PricingInfo) fillHourlyBase(sku *billingpb.Sku, correctTieredRate func(*billingpb.PricingExpression_TierRate) bool) {
+	p.UsageUnit, p.HourlyUnitPrice, p.CurrencyType = billing.PricingInfo(sku, correctTieredRate)
 }
 
-func (p *PricingInfo) fillMonthlyBase(sku *billingpb.Sku) {
-	usageUnit, monthly, currencyType := billing.PricingInfo(sku)
+func (p *PricingInfo) fillMonthlyBase(sku *billingpb.Sku, correctTieredRate func(*billingpb.PricingExpression_TierRate) bool) {
+	usageUnit, monthly, currencyType := billing.PricingInfo(sku, correctTieredRate)
 	p.UsageUnit = usageUnit
 	p.HourlyUnitPrice = monthly / hourlyToMonthly
 	p.CurrencyType = currencyType
@@ -28,7 +28,6 @@ func (p *PricingInfo) fillMonthlyBase(sku *billingpb.Sku) {
 type ResourceState interface {
 	CompletePricingInfo(catalog *billing.ComputeEngineCatalog) error
 	GetWebTables(stateNum int) *web.PricingTypeTables
-	GetSummary() string
 }
 
 // skuObject is the interface for SKU types (core, memory etc.)


### PR DESCRIPTION
Some SKUs have multiple tier rates and initially only the first was
chosen. Now, tier rate is determined via a parsed function that
determines whether the tiered rate is the good one. For core and
RAM instances, the function always returns true (there is only one tier
rate). For disks, the function returns true for a startUsageAmount <=
size of the disk. This verification is done from the tier rate with the
highest startUsageAmount to the lowest. Aditionally cleaned
ResourceState interface and errors from ComputeDiskState.GetWebTables().